### PR TITLE
URLs should be generated with WordPress API

### DIFF
--- a/MultisiteLanguageSwitcher.php
+++ b/MultisiteLanguageSwitcher.php
@@ -29,6 +29,8 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 if ( !class_exists( 'MslsPlugin' ) ) {
     if ( !defined( 'MSLS_PLUGIN_PATH' ) )  
         define( 'MSLS_PLUGIN_PATH', plugin_basename( __FILE__ ) );
+	if ( !defined( 'MSLS_PLUGIN__FILE__' ) )
+    	define( 'MSLS_PLUGIN__FILE__', __FILE__ );
 
     require_once dirname( __FILE__ ) . '/includes/MslsOutput.php';
     register_activation_hook( __FILE__, 'MslsPlugin::activate' );

--- a/includes/MslsOptions.php
+++ b/includes/MslsOptions.php
@@ -203,13 +203,7 @@ class MslsOptions extends MslsGetSet implements IMslsRegistryInstance {
      * @return string
      */
     public function get_url( $dir ) {
-        $url = sprintf(
-            '%s/%s/%s',
-            WP_PLUGIN_URL, 
-            dirname( MSLS_PLUGIN_PATH ),
-            $dir
-        );
-        return esc_url( $url );
+        return esc_url( plugins_url( $dir, MSLS_PLUGIN__FILE__ ) );
     }
 
     /**


### PR DESCRIPTION
Currently the URLs for the src parameter of the flag icons in the backend (e.g. on /wp-admin/edit.php or /wp-admin/edit-tags.php?taxonomy=category) are created with the fixed WP_PLUGINS_URL constant, which does not make use of SSL detection. When browsing the backend via https://, this leads to "mixed content" warnings, as the icons/flags are loaded via http://.
Instead of using the constant, the WordPress API function plugins_url() which wraps the constant, should be used.
As that function needs the value of **FILE** from the main plugin file, I introduced a constant for this in the commit.
