### PR TITLE
Update MslsOptions.php

### DIFF
--- a/includes/MslsOptions.php
+++ b/includes/MslsOptions.php
@@ -210,7 +210,7 @@ class MslsOptions extends MslsGetSet implements IMslsRegistryInstance {
 	 */
 	public function get_flag_url( $language ) {
 		$url = ( 
-			!is_admin() && isset( $this->image_url ) ?
+			isset( $this->image_url ) ?
 			$this->__get( 'image_url' ) :
 			$this->get_url( 'flags' )
 		);


### PR DESCRIPTION
Also show changed flag icons in the admin menu. This is especially helpful if wordpress is running with a language that is not known to Multisite Language Switcher (no flag icon available).
