### PR TITLE
Performance improvments

### DIFF
--- a/includes/MslsOutput.php
+++ b/includes/MslsOutput.php
@@ -91,7 +91,7 @@ class MslsOutput extends MslsMain {
 			
 			switch_to_blog( $current_site );
 			$GLOBALS['_wp_switched_stack'] = array();
-                        $GLOBALS['switched']           = FALSE;
+			$GLOBALS['switched']           = FALSE;
 		}
 
 		return $arr;

--- a/includes/MslsOutput.php
+++ b/includes/MslsOutput.php
@@ -90,6 +90,8 @@ class MslsOutput extends MslsMain {
 			}
 			
 			switch_to_blog( $current_site );
+			$GLOBALS['_wp_switched_stack'] = array();
+                        $GLOBALS['switched']           = FALSE;
 		}
 
 		return $arr;

--- a/includes/MslsOutput.php
+++ b/includes/MslsOutput.php
@@ -41,7 +41,9 @@ class MslsOutput extends MslsMain {
 		if ( $blogs ) {
 			$mydata = MslsOptions::create();
 			$link   = MslsLink::create( $display );
-
+                        
+                        $current_site = get_current_blog_id();
+                        
 			foreach ( $blogs as $blog ) {
 				$language = $blog->get_language();
 				$url      = $mydata->get_current_link();
@@ -61,8 +63,6 @@ class MslsOutput extends MslsMain {
 						$url       = $mydata->get_permalink( $language );
 						$link->txt = $blog->get_description();
 					}
-
-					restore_current_blog();
 				}
 
 				$link->src = MslsOptions::instance()->get_flag_url( $language );
@@ -88,6 +88,8 @@ class MslsOutput extends MslsMain {
 					);
 				}
 			}
+			
+			switch_to_blog( $current_site );
 		}
 
 		return $arr;


### PR DESCRIPTION
Using restore_current_blog() after each switch doubles the time that is needed just for switching.
info: http://wordpress.stackexchange.com/questions/89113/restore-current-blog-vs-switch-to-blog

restore_current_blog is used many time in the plug-in. plase, fix every where.

thank you for Multisite-Language-Switcher!