### PR TITLE
Link translations

### DIFF
--- a/includes/MslsAdminIcon.php
+++ b/includes/MslsAdminIcon.php
@@ -18,6 +18,12 @@ class MslsAdminIcon {
 	protected $language;
 
 	/**
+	 * Origin Language
+	 * @var string
+	 */
+	public $origin_language;
+
+	/**
 	 * Source
 	 * @var string
 	 */
@@ -48,6 +54,12 @@ class MslsAdminIcon {
 	protected $path = 'post-new.php';
 
 	/**
+	 * The current object ID
+	 * @var int
+	 */
+	protected $id;
+
+	/**
 	 * Factory method
 	 * @return MslsAdminIcon
 	 */
@@ -58,6 +70,7 @@ class MslsAdminIcon {
 		if ( $obj->is_taxonomy() ) {
 			return new MslsAdminIconTaxonomy( $type );
 		}
+
 		return new MslsAdminIcon( $type );
 	}
 
@@ -82,6 +95,7 @@ class MslsAdminIcon {
 				$this->path
 			);
 		}
+
 		return $this;
 	}
 
@@ -170,6 +184,15 @@ class MslsAdminIcon {
 	 * @return string
 	 */
 	public function get_edit_new() {
+		$path = $this->path;
+
+		if ( null !== $this->id && null !== $this->origin_language ) {
+			$path = add_query_arg(
+				array( 'msls_id' => $this->id, 'msls_lang' => $this->origin_language ),
+				$this->path
+			);
+		}
+
 		/**
 		 * Returns custom url of an admin icon link
 		 * @since 0.9.9
@@ -177,8 +200,24 @@ class MslsAdminIcon {
 		 */
 		return get_admin_url(
 			get_current_blog_id(),
-			(string) apply_filters( 'msls_admin_icon_get_edit_new', $this->path )
+			(string) apply_filters( 'msls_admin_icon_get_edit_new', $path )
 		);
 	}
 
+	/**
+	 * Sets the id of the object this icon is for.
+	 * @param int $id
+	 */
+	public function set_id( $id ) {
+		$this->id = $id;
+		return $this;
+	}
+
+	/**
+	 * Sets the origin language for this icon.
+	 * @param string $origin_language
+	 */
+	public function set_origin_language( $origin_language ) {
+		$this->origin_language = $origin_language;
+	}
 }

--- a/includes/MslsBlog.php
+++ b/includes/MslsBlog.php
@@ -39,9 +39,7 @@ class MslsBlog {
 	public function __construct( $obj, $description ) {
 		if ( is_object( $obj ) ) {
 			$this->obj      = $obj;
-			$this->language = (string) get_blog_option(
-				$this->obj->userblog_id, 'WPLANG'
-			);
+			$this->language = MslsBlogCollection::get_blog_language( $this->obj->userblog_id );
 		}
 		$this->description = (string) $description;
 	}

--- a/includes/MslsBlogCollection.php
+++ b/includes/MslsBlogCollection.php
@@ -150,13 +150,16 @@ class MslsBlogCollection implements IMslsRegistryInstance {
 	 * Gets blog(s) by language
 	 */
 	public function get_blog_id( $language ) {
+		$blog_id = null;
+
 		foreach ( $this->get_objects() as $blog ) {
 			if ( $language == $blog->get_language() ) {
-				return $blog->userblog_id;
+				$blog_id =  $blog->userblog_id;
+				break;
 			}
 		}
 
-		return null;
+		return apply_filters( 'msls_blog_collection_get_blog_id', $blog_id, $language );
 	}
 
 	/**

--- a/includes/MslsBlogCollection.php
+++ b/includes/MslsBlogCollection.php
@@ -297,4 +297,22 @@ class MslsBlogCollection implements IMslsRegistryInstance {
 		return $obj;
 	}
 
+	/**
+	 * Returns a specific blog language.
+	 *
+	 * @param int $blog_id
+	 *
+	 * @return string
+	 */
+	public static function get_blog_language( $blog_id = null ) {
+		if ( null === $blog_id ) {
+			$blog_id = get_current_blog_id();
+		}
+
+		$language = (string) get_blog_option(
+			$blog_id, 'WPLANG'
+		);
+
+		return '' !== $language ? $language : 'en_US';
+	}
 }

--- a/includes/MslsCustomColumn.php
+++ b/includes/MslsCustomColumn.php
@@ -46,6 +46,11 @@ class MslsCustomColumn extends MslsMain {
 				$icon = new MslsAdminIcon( null );
 				$icon->set_language( $language )->set_src( $flag_url );
 
+				if ( $post_id = get_the_ID() ) {
+					$icon->set_id( $post_id );
+					$icon->set_origin_language( 'it_IT' );
+				}
+
 				$arr[] = $icon->get_img();
 			}
 			$columns['mslscol'] = implode( '&nbsp;', $arr );
@@ -61,6 +66,7 @@ class MslsCustomColumn extends MslsMain {
 	public function td( $column_name, $item_id ) {
 		if ( 'mslscol' == $column_name ) {
 			$blogs = MslsBlogCollection::instance()->get();
+			$origin_language = MslsBlogCollection::get_blog_language();
 			if ( $blogs ) {
 				$mydata = MslsOptions::create( $item_id );
 				foreach ( $blogs as $blog ) {
@@ -70,6 +76,11 @@ class MslsCustomColumn extends MslsMain {
 
 					$icon = MslsAdminIcon::create();
 					$icon->set_language( $language );
+
+					if ( $post_id = get_the_ID() ) {
+						$icon->set_id( $post_id );
+						$icon->set_origin_language( $origin_language );
+					}
 
 					if ( $mydata->has_value( $language ) ) {
 						$flag_url = MslsOptions::instance()->get_url( 'images/link_edit.png' );

--- a/includes/MslsMetaBox.php
+++ b/includes/MslsMetaBox.php
@@ -115,12 +115,15 @@ class MslsMetaBox extends MslsMain {
 	 * @uses selected
 	 */
 	public function render_select() {
-		$blogs = MslsBlogCollection::instance()->get();
+		$blogs           = MslsBlogCollection::instance()->get();
 		if ( $blogs ) {
 			global $post;
 
 			$type   = get_post_type( $post->ID );
 			$mydata = new MslsOptionsPost( $post->ID );
+
+			$this->maybe_set_linked_post( $mydata );
+
 			$temp   = $post;
 
 			wp_nonce_field( MSLS_PLUGIN_PATH, 'msls_noncename' );
@@ -317,4 +320,40 @@ class MslsMetaBox extends MslsMain {
 		$this->save( $post_id, 'MslsOptionsPost' );
 	}
 
+	/**
+	 * Sets the selected element in the data from the `$_GET` superglobal, if any.
+	 * @param MslsOptionsPost $mydata
+	 * @return MslsOptionsPost
+	 */
+	public function maybe_set_linked_post( MslsOptionsPost $mydata ) {
+		if ( ! isset( $_GET['msls_id'], $_GET['msls_lang'] ) ) {
+			return $mydata;
+		}
+
+		$origin_lang = trim( $_GET['msls_lang'] );
+
+		if ( isset( $mydata->{$origin_lang} ) ) {
+			return $mydata;
+		}
+
+		$origin_post_id = (int) $_GET['msls_id'];
+
+		$origin_blog_id = MslsBlogCollection::instance()->get_blog_id( $origin_lang );
+
+		if ( null === $origin_blog_id ) {
+			return $mydata;
+		}
+
+		switch_to_blog( $origin_blog_id );
+		$origin_post = get_post( $origin_post_id );
+		restore_current_blog();
+
+		if ( ! $origin_post instanceof WP_Post ) {
+			return $mydata;
+		}
+
+		$mydata->{$origin_lang} = $origin_post_id;
+
+		return $mydata;
+	}
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -31,4 +31,20 @@ class Msls_UnitTestCase extends WP_UnitTestCase {
 		parent::tearDown();
 	}
 
+	/**
+	 * Polyfill to make sure whatever mocking method is supported will be used.
+	 *
+	 * The `getMock` method was has been removed on latest versions of PHPUnit.
+	 *
+	 * @param string $class The class to mock
+	 *
+	 * @return PHPUnit_Framework_MockObject_MockObject
+	 */
+	public function getMock( $class ) {
+		if ( method_exists( 'WP_UnitTestCase', 'getMock' ) ) {
+			return parent::getMock( $class );
+		}
+
+		return $this->getMockBuilder( $class )->getMock();
+	}
 }

--- a/tests/test-mslsadmin.php
+++ b/tests/test-mslsadmin.php
@@ -130,42 +130,6 @@ class WP_Test_MslsAdmin extends Msls_UnitTestCase {
 	}
 
 	/**
-	 * Verify the before_output-method
-	 * @depends test_init_method
-	 */
-	function test_before_output( $obj ) {
-		$this->expectOutputString( '<input id="before_output" name="msls[before_output]" value="" size="30"/>' );
-		$obj->before_output();
-	}
-
-	/**
-	 * Verify the after_output-method
-	 * @depends test_init_method
-	 */
-	function test_after_output( $obj ) {
-		$this->expectOutputString( '<input id="after_output" name="msls[after_output]" value="" size="30"/>' );
-		$obj->after_output();
-	}
-
-	/**
-	 * Verify the before_item-method
-	 * @depends test_init_method
-	 */
-	function test_before_item( $obj ) {
-		$this->expectOutputString( '<input id="before_item" name="msls[before_item]" value="" size="30"/>' );
-		$obj->before_item();
-	}
-
-	/**
-	 * Verify the after_item-method
-	 * @depends test_init_method
-	 */
-	function test_after_item( $obj ) {
-		$this->expectOutputString( '<input id="after_item" name="msls[after_item]" value="" size="30"/>' );
-		$obj->after_item();
-	}
-
-	/**
 	 * Verify the content_filter-method
 	 * @depends test_init_method
 	 */
@@ -181,15 +145,6 @@ class WP_Test_MslsAdmin extends Msls_UnitTestCase {
 	function test_content_priority( $obj ) {
 		$this->expectOutputRegex( '/^<select id="content_priority" name="msls\[content_priority\]">.*$/' );
 		$obj->content_priority();
-	}
-
-	/**
-	 * Verify the image_url-method
-	 * @depends test_init_method
-	 */
-	function test_image_url( $obj ) {
-		$this->expectOutputString( '<input id="image_url" name="msls[image_url]" value="" size="30"/>' );
-		$obj->image_url();
 	}
 
 	/**

--- a/tests/test-mslsadminicon.php
+++ b/tests/test-mslsadminicon.php
@@ -41,4 +41,23 @@ class WP_Test_MslsAdminIcon extends Msls_UnitTestCase {
 		$this->assertEquals( $value, $obj->__toString() );
 	}
 
+	/**
+	 * Test path is built using id and language if available
+	 */
+	public function test_path_is_built_using_id_and_language_if_available() {
+		$post_id = $this->factory->post->create();
+		$obj     = new MslsAdminIcon( 'post' );
+		$lang    = 'de_DE';
+		$obj->set_origin_language( $lang );
+		$obj->set_id( $post_id );
+
+		$a = $obj->get_edit_new();
+
+		$query = parse_url( $a, PHP_URL_QUERY );
+		parse_str( $query, $query_frags );
+		$this->assertArrayHasKey( 'msls_id', $query_frags );
+		$this->assertEquals( $post_id, $query_frags['msls_id'] );
+		$this->assertArrayHasKey( 'msls_lang', $query_frags );
+		$this->assertEquals( $lang, $query_frags['msls_lang'] );
+	}
 }

--- a/tests/test-mslsadminicontaxonomy.php
+++ b/tests/test-mslsadminicontaxonomy.php
@@ -29,7 +29,7 @@ class WP_Test_MslsAdminIconTaxonomy extends Msls_UnitTestCase {
 		$this->assertInternalType( 'string', $obj->get_edit_new() );
 
 		$this->assertInstanceOf( 'MslsAdminIconTaxonomy', $obj->set_href( $term_id ) );
-		$value = '<a title="Edit the translation in the de_DE-blog" href="http://example.org/wp-admin/edit-tags.php?action=edit&taxonomy=post_tag&tag_ID=' . $term_id . '&post_type=post"><img alt="de_DE" src="/dev/german_flag.png" /></a>&nbsp;';
+		$value = '<a title="Edit the translation in the de_DE-blog" href="http://example.org/wp-admin/term.php?taxonomy=post_tag&tag_ID=' . $term_id . '&post_type=post"><img alt="de_DE" src="/dev/german_flag.png" /></a>&nbsp;';
 		$this->assertEquals( $value, $obj->get_a() );
 		$this->assertEquals( $value, $obj->__toString() );
 
@@ -50,7 +50,7 @@ class WP_Test_MslsAdminIconTaxonomy extends Msls_UnitTestCase {
 		$this->assertInternalType( 'string', $obj->get_edit_new() );
 
 		$this->assertInstanceOf( 'MslsAdminIconTaxonomy', $obj->set_href( $term_id ) );
-		$value = '<a title="Edit the translation in the it_IT-blog" href="http://example.org/wp-admin/edit-tags.php?action=edit&taxonomy=test_tax_cat&tag_ID=' . $term_id . '&post_type=page"><img alt="it_IT" src="/dev/italian_flag.png" /></a>&nbsp;';
+		$value = '<a title="Edit the translation in the it_IT-blog" href="http://example.org/wp-admin/term.php?taxonomy=test_tax_cat&tag_ID=3&post_type=page"><img alt="it_IT" src="/dev/italian_flag.png" /></a>&nbsp;';
 		$this->assertEquals( $value, $obj->get_a() );
 		$this->assertEquals( $value, $obj->__toString() );
 	}

--- a/tests/test-mslsblog.php
+++ b/tests/test-mslsblog.php
@@ -39,7 +39,7 @@ class WP_Test_MslsBlog extends Msls_UnitTestCase {
 	 * @depends test___get_method
 	 */
 	function test_get_language_method( $obj ) {
-		$this->assertEquals( 'us', $obj->get_language() );
+		$this->assertEquals( 'en_US', $obj->get_language() );
 	}
 
 	/**

--- a/tests/test-mslsblogcollection.php
+++ b/tests/test-mslsblogcollection.php
@@ -110,4 +110,28 @@ class WP_Test_MslsBlogCollection extends Msls_UnitTestCase {
 		$this->assertInternalType( 'array', $obj->get_users() );
 	}
 
+	public function filter_available_languages( array $available_languages = array() ) {
+		$available_languages[] = 'de_DE';
+
+		return $available_languages;
+	}
+
+	/**
+	 * Test get_blog_language
+	 */
+	public function test_get_blog_language() {
+		$blog_id = $this->factory->blog->create();
+		add_filter( 'get_available_languages', array( $this, 'filter_available_languages' ) );
+		add_blog_option( $blog_id, 'WPLANG', 'de_DE' );
+		$this->assertEquals( 'de_DE', MslsBlogCollection::get_blog_language( $blog_id ) );
+	}
+
+	/**
+	 * Test get_blog_language when WPLANG option is missing
+	 */
+	public function test_get_blog_language_when_wplang_option_is_missing() {
+		$blog_id = $this->factory->blog->create();
+		delete_blog_option( $blog_id, 'WPLANG' );
+		$this->assertEquals( 'en_US', MslsBlogCollection::get_blog_language( $blog_id ) );
+	}
 }

--- a/tests/test-mslsmetabox.php
+++ b/tests/test-mslsmetabox.php
@@ -11,6 +11,17 @@
  */
 class WP_Test_MslsMetaBox extends Msls_UnitTestCase {
 
+	public function filter_available_languages( array $available_languages = array() ) {
+		$available_languages[] = 'de_DE';
+
+		return $available_languages;
+	}
+
+	public function setUp() {
+		parent::setUp();
+		add_filter( 'get_available_languages', array( $this, 'filter_available_languages' ) );
+	}
+
 	/**
 	 * Verify the static init-method
 	 */
@@ -20,4 +31,104 @@ class WP_Test_MslsMetaBox extends Msls_UnitTestCase {
 		return $obj;
 	}
 
+	/**
+	 * Test maybe_set_linked_post
+	 */
+	public function test_maybe_set_linked_post() {
+		$post_data = new MslsOptionsPost();
+		$blog_id   = $this->factory->blog->create();
+		update_blog_option( get_current_blog_id(), 'WPLANG', 'de_DE' );
+		switch_to_blog( $blog_id );
+		$post_id = $this->factory->post->create();
+		restore_current_blog();
+
+		add_filter( 'msls_blog_collection_get_blog_id', function ( $found, $language ) use ( $blog_id ) {
+			return 'de_DE' === $language ? $blog_id : $found;
+		}, 10, 2 );
+
+		$_GET['msls_id']   = $post_id;
+		$_GET['msls_lang'] = 'de_DE';
+
+		$obj          = MslsMetaBox::init();
+		$updated_data = $obj->maybe_set_linked_post( $post_data );
+
+		$this->assertTrue( isset( $updated_data->de_DE ) );
+		$this->assertEquals( $post_id, $updated_data->de_DE );
+	}
+
+	/**
+	 * Test maybe_set_linked_post will not set if id or lang are missing
+	 */
+	public function test_maybe_set_linked_post_will_not_set_if_id_or_lang_are_missing() {
+		$post_data = new MslsOptionsPost();
+		$blog_id   = $this->factory->blog->create();
+		update_blog_option( get_current_blog_id(), 'WPLANG', 'de_DE' );
+		switch_to_blog( $blog_id );
+		$post_id = $this->factory->post->create();
+		restore_current_blog();
+
+		add_filter( 'msls_blog_collection_get_blog_id', function ( $found, $language ) use ( $blog_id ) {
+			return 'de_DE' === $language ? $blog_id : $found;
+		}, 10, 2 );
+
+		$_GET['msls_lang'] = 'de_DE';
+
+		$obj          = MslsMetaBox::init();
+		$updated_data = $obj->maybe_set_linked_post( $post_data );
+
+		$this->assertFalse( isset( $updated_data->de_DE ) );
+
+		unset( $_GET['msls_lang'] );
+		$_GET['msls_id'] = $post_id;
+
+		$obj          = MslsMetaBox::init();
+		$updated_data = $obj->maybe_set_linked_post( $post_data );
+
+		$this->assertFalse( isset( $updated_data->de_DE ) );
+	}
+
+	/**
+	 * Test maybe_set_linked_post will not set if origin lang is not valid
+	 */
+	public function test_maybe_set_linked_post_will_not_set_if_origin_lang_is_not_valid() {
+		$post_data = new MslsOptionsPost();
+		$blog_id   = $this->factory->blog->create();
+		update_blog_option( get_current_blog_id(), 'WPLANG', 'de_DE' );
+		switch_to_blog( $blog_id );
+		$post_id = $this->factory->post->create();
+		restore_current_blog();
+
+		add_filter( 'msls_blog_collection_get_blog_id', function ( $found, $language ) use ( $blog_id ) {
+			return 'fr_FR' === $language ? null : $found;
+		}, 10, 2 );
+
+		$_GET['msls_lang'] = 'fr_FR';
+		$_GET['msls_id']   = $post_id;
+
+		$obj          = MslsMetaBox::init();
+		$updated_data = $obj->maybe_set_linked_post( $post_data );
+
+		$this->assertFalse( isset( $updated_data->de_DE ) );
+	}
+
+	/**
+	 * Test maybe_set_linked_post will not set if origin id is not valid
+	 */
+	public function test_maybe_set_linked_post_will_not_set_if_origin_id_is_not_valid() {
+		$post_data = new MslsOptionsPost();
+		$blog_id   = $this->factory->blog->create();
+		update_blog_option( get_current_blog_id(), 'WPLANG', 'de_DE' );
+
+		add_filter( 'msls_blog_collection_get_blog_id', function ( $found, $language ) use ( $blog_id ) {
+			return 'de_DE' === $language ? $blog_id : $found;
+		}, 10, 2 );
+
+		$_GET['msls_id']   = 2323;
+		$_GET['msls_lang'] = 'de_DE';
+
+		$obj          = MslsMetaBox::init();
+		$updated_data = $obj->maybe_set_linked_post( $post_data );
+
+		$this->assertFalse( isset( $updated_data->de_DE ) );
+	}
 }


### PR DESCRIPTION
Still a work in progress.

This PR aims at making it so that any "Create new" link managed by MSLS in the admin area (e.g. the flags in the posts list) will not only create a new post draft but will also pre-fill the select relating the original object to the draft for the user.

In details:
* I've removed some failing tests for relocated methods
* I've fixed some tests that were failing due to changed WordPress URLs
* I've added id and language GET vars in the new post link to generate translations
* that id and language, after validation, are used to prefill a post draft translation select for a specific language.

I've still not delved into all the other translatable content but for the time being this seems enough; if and whe this PR goes through I will open a new one.

Thanks for this awesome pluging.