### PR TITLE
Try to load the autoload file only if available

### DIFF
--- a/MultisiteLanguageSwitcher.php
+++ b/MultisiteLanguageSwitcher.php
@@ -27,7 +27,9 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
-require __DIR__. '/vendor/autoload.php';
+if ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
+	require __DIR__ . '/vendor/autoload.php';
+}
 
 /**
  * MultisiteLanguageSwitcher


### PR DESCRIPTION
When the plugin is required in a site composer.json file then its dependencies, including the `autoload.php` file, will be managed on a site level and in the site `vendor` folder.
Assuming the `autoload.php` file will be in the plugin own `vendor` folder would generate an error; this check avoids that.