### PR TITLE
Fixing for when the queried tax is a WooCommerce taxonomy

### DIFF
--- a/includes/MslsOptionsTax.php
+++ b/includes/MslsOptionsTax.php
@@ -72,15 +72,25 @@ class MslsOptionsTax extends MslsOptions {
 	 * Get the queried taxonomy
 	 * @return string
 	 */
-	public function get_tax_query() {
-		global $wp_query;
+    public function get_tax_query() {
+        global $wp_query;
 
-		if ( isset( $wp_query->tax_query->queries[0]['taxonomy'] ) ) {
-			return $wp_query->tax_query->queries[0]['taxonomy'];
-		}
+        if (class_exists('WooCommerce')){
+            if (is_woocommerce()){
+                if ( isset( $wp_query->tax_query->queries[1]['taxonomy'] ) ) {
+                    return $wp_query->tax_query->queries[1]['taxonomy'];
+                }
+            }
+        } else {
+            if ( isset( $wp_query->tax_query->queries[0]['taxonomy'] ) ) {
+                return $wp_query->tax_query->queries[0]['taxonomy'];
+            }
+        }
 
-		return parent::get_tax_query();
-	}
+
+
+        return parent::get_tax_query();
+    }
 
 	/**
 	 * Get postlink


### PR DESCRIPTION
When trying to connect a WooCommerce category, you get product_visibility as the queried object, instead of product_cat, so the $url is blank and it connects to the homepage instead of the actual category page in the other language. This checks for WooCommerce and if it is a woocommerce taxonomy it asks for the second value in the array instead of the first one: http://take.ms/Sw3Ztn