### PR TITLE
Settings page: improve accessibility

### DIFF
--- a/includes/ContentImport/MetaBox.php
+++ b/includes/ContentImport/MetaBox.php
@@ -49,7 +49,7 @@ class MetaBox extends MslsRegistryInstance {
 					$this->data = [
 						'msls_import'  => "{$blog}|{$id}",
 					];
-					$output .= sprintf( '<a class="button-primary thickbox" href="%s" title="%s">%s</a>',
+					$output .= sprintf( '<a class="button button-primary thickbox" href="%s" title="%s">%s</a>',
 						$this->inline_thickbox_url( $this->data ),
 						$label,
 						$label
@@ -136,7 +136,7 @@ class MetaBox extends MslsRegistryInstance {
                 <div>
                     <input
                             type="submit"
-                            class="button-primary"
+                            class="button button-primary"
                             value="<?php esc_html_e( 'Import Content', 'multisite-language-switcher' ) ?>"
                     >
                 </div>

--- a/includes/MslsAdmin.php
+++ b/includes/MslsAdmin.php
@@ -208,7 +208,7 @@ class MslsAdmin extends MslsMain {
 		add_settings_field( 'blog_language', __( 'Blog Language', 'multisite-language-switcher' ), array(
 			$this,
 			'blog_language'
-		), __CLASS__, 'language_section' );
+		), __CLASS__, 'language_section', array( 'label_for' => 'blog_language' ) );
 
 		/**
 		 * Lets you add your own field to the language section
@@ -228,7 +228,7 @@ class MslsAdmin extends MslsMain {
 		add_settings_field( 'display', __( 'Display', 'multisite-language-switcher' ), array(
 			$this,
 			'display'
-		), __CLASS__, 'main_section' );
+		), __CLASS__, 'main_section', array( 'label_for' => 'display' ) );
 		add_settings_field( 'sort_by_description', __( 'Sort output by description', 'multisite-language-switcher' ), array(
 			$this,
 			'sort_by_description'
@@ -244,23 +244,23 @@ class MslsAdmin extends MslsMain {
 		add_settings_field( 'description', __( 'Description', 'multisite-language-switcher' ), array(
 			$this,
 			'description'
-		), __CLASS__, 'main_section' );
+		), __CLASS__, 'main_section', array( 'label_for' => 'description' ) );
 		add_settings_field( 'before_output', __( 'Text/HTML before the list', 'multisite-language-switcher' ), array(
 			$this,
 			'text_before_output'
-		), __CLASS__, 'main_section' );
+		), __CLASS__, 'main_section', array( 'label_for' => 'before_output' ) );
 		add_settings_field( 'after_output', __( 'Text/HTML after the list', 'multisite-language-switcher' ), array(
 			$this,
 			'text_after_output'
-		), __CLASS__, 'main_section' );
+		), __CLASS__, 'main_section', array( 'label_for' => 'after_output' ) );
 		add_settings_field( 'before_item', __( 'Text/HTML before each item', 'multisite-language-switcher' ), array(
 			$this,
 			'text_before_item'
-		), __CLASS__, 'main_section' );
+		), __CLASS__, 'main_section', array( 'label_for' => 'before_item' ) );
 		add_settings_field( 'after_item', __( 'Text/HTML after each item', 'multisite-language-switcher' ), array(
 			$this,
 			'text_after_item'
-		), __CLASS__, 'main_section' );
+		), __CLASS__, 'main_section', array( 'label_for' => 'after_item' ) );
 		add_settings_field( 'content_filter', __( 'Add hint for available translations', 'multisite-language-switcher' ), array(
 			$this,
 			'content_filter'
@@ -268,7 +268,7 @@ class MslsAdmin extends MslsMain {
 		add_settings_field( 'content_priority', __( 'Hint priority', 'multisite-language-switcher' ), array(
 			$this,
 			'content_priority'
-		), __CLASS__, 'main_section' );
+		), __CLASS__, 'main_section', array( 'label_for' => 'content_priority' ) );
 
 		/**
 		 * Lets you add your own field to the main section
@@ -292,11 +292,11 @@ class MslsAdmin extends MslsMain {
 		add_settings_field( 'image_url', __( 'Custom URL for flag-images', 'multisite-language-switcher' ), array(
 			$this,
 			'text_image_url'
-		), __CLASS__, 'advanced_section' );
+		), __CLASS__, 'advanced_section', array( 'label_for' => 'image_url' ) );
 		add_settings_field( 'reference_user', __( 'Reference user', 'multisite-language-switcher' ), array(
 			$this,
 			'reference_user'
-		), __CLASS__, 'advanced_section' );
+		), __CLASS__, 'advanced_section', array( 'label_for' => 'reference_user' ) );
 		add_settings_field( 'exclude_current_blog', __( 'Exclude this blog from output', 'multisite-language-switcher' ), array(
 			$this,
 			'exclude_current_blog'
@@ -324,7 +324,14 @@ class MslsAdmin extends MslsMain {
 	public function rewrites_section() {
 		foreach ( get_post_types( [ 'public' => true ], 'objects' ) as $key => $object ) {
 			$title = sprintf( __( '%s Slug', 'multisite-language-switcher' ), $object->label );
-			add_settings_field( "rewrite_{$key}", $title, [ $this, "rewrite_{$key}" ], __CLASS__, 'rewrites_section' );
+			add_settings_field(
+				"rewrite_{$key}",
+				$title,
+				[ $this, "rewrite_{$key}" ],
+				__CLASS__,
+				'rewrites_section',
+				array( 'label_for' => "rewrite_{$key}" )
+			);
 		}
 
 		/**

--- a/includes/MslsAdmin.php
+++ b/includes/MslsAdmin.php
@@ -130,7 +130,7 @@ class MslsAdmin extends MslsMain {
 		do_settings_sections( __CLASS__ );
 
 		printf(
-			'<p class="submit"><input name="Submit" type="submit" class="button-primary" value="%s" /></p></form></div>',
+			'<p class="submit"><input name="Submit" type="submit" class="button button-primary" value="%s" /></p></form></div>',
 			( $this->options->is_empty() ? __( 'Configure', 'multisite-language-switcher' ) : __( 'Update', 'multisite-language-switcher' ) )
 		);
 	}

--- a/includes/MslsAdmin.php
+++ b/includes/MslsAdmin.php
@@ -583,7 +583,7 @@ class MslsAdmin extends MslsMain {
 	 */
 	public function render_input( $key, $size = '30', $default = '', $readonly = false ) {
 		return sprintf(
-			'<input id="%1$s" name="msls[%1$s]" value="%2$s" size="%3$s"%4$s/>',
+			'<input type="text" class="regular-text" id="%1$s" name="msls[%1$s]" value="%2$s" size="%3$s"%4$s/>',
 			$key,
 			esc_attr( ! empty( $this->options->$key ) ? $this->options->$key : $default ),
 			$size,

--- a/includes/MslsAdmin.php
+++ b/includes/MslsAdmin.php
@@ -229,15 +229,15 @@ class MslsAdmin extends MslsMain {
 			$this,
 			'display'
 		), __CLASS__, 'main_section', array( 'label_for' => 'display' ) );
-		add_settings_field( 'sort_by_description', __( 'Sort output by description', 'multisite-language-switcher' ), array(
+		add_settings_field( 'sort_by_description', __( 'Sort languages', 'multisite-language-switcher' ), array(
 			$this,
 			'sort_by_description'
 		), __CLASS__, 'main_section' );
-		add_settings_field( 'output_current_blog', __( 'Display link to the current language', 'multisite-language-switcher' ), array(
+		add_settings_field( 'output_current_blog', __( 'Current language link', 'multisite-language-switcher' ), array(
 			$this,
 			'output_current_blog'
 		), __CLASS__, 'main_section' );
-		add_settings_field( 'only_with_translation', __( 'Show only links with a translation', 'multisite-language-switcher' ), array(
+		add_settings_field( 'only_with_translation', __( 'Translation links', 'multisite-language-switcher' ), array(
 			$this,
 			'only_with_translation'
 		), __CLASS__, 'main_section' );
@@ -261,7 +261,7 @@ class MslsAdmin extends MslsMain {
 			$this,
 			'text_after_item'
 		), __CLASS__, 'main_section', array( 'label_for' => 'after_item' ) );
-		add_settings_field( 'content_filter', __( 'Add hint for available translations', 'multisite-language-switcher' ), array(
+		add_settings_field( 'content_filter', __( 'Available translations hint', 'multisite-language-switcher' ), array(
 			$this,
 			'content_filter'
 		), __CLASS__, 'main_section' );
@@ -285,7 +285,7 @@ class MslsAdmin extends MslsMain {
 	 * @codeCoverageIgnore
 	 */
 	public function advanced_section() {
-		add_settings_field( 'activate_autocomplete', __( 'Activate experimental autocomplete inputs', 'multisite-language-switcher' ), array(
+		add_settings_field( 'activate_autocomplete', __( 'Autocomplete', 'multisite-language-switcher' ), array(
 			$this,
 			'activate_autocomplete'
 		), __CLASS__, 'advanced_section' );
@@ -297,11 +297,11 @@ class MslsAdmin extends MslsMain {
 			$this,
 			'reference_user'
 		), __CLASS__, 'advanced_section', array( 'label_for' => 'reference_user' ) );
-		add_settings_field( 'exclude_current_blog', __( 'Exclude this blog from output', 'multisite-language-switcher' ), array(
+		add_settings_field( 'exclude_current_blog', __( 'Exclude blog', 'multisite-language-switcher' ), array(
 			$this,
 			'exclude_current_blog'
 		), __CLASS__, 'advanced_section' );
-		add_settings_field( 'activate_content_import', __( 'Activate the content import functionality', 'multisite-language-switcher' ), array(
+		add_settings_field( 'activate_content_import', __( 'Content import', 'multisite-language-switcher' ), array(
 			$this,
 			'activate_content_import'
 		), __CLASS__, 'advanced_section' );
@@ -385,7 +385,14 @@ class MslsAdmin extends MslsMain {
 	 * input fields in the backend instead of the traditional select-menus.
 	 */
 	public function activate_autocomplete() {
-		echo $this->render_checkbox( 'activate_autocomplete' );
+		printf(
+			'%s %s',
+			$this->render_checkbox( 'activate_autocomplete' ),
+			$this->render_checkbox_label(
+				'activate_autocomplete',
+				__( 'Activate experimental autocomplete inputs', 'multisite-language-switcher' )
+			)
+		);
 	}
 
 	/**
@@ -395,17 +402,31 @@ class MslsAdmin extends MslsMain {
 	 * in the backend instead of the traditional select-menus.
 	 */
 	public function activate_content_import() {
-		echo $this->render_checkbox( 'activate_content_import' );
+		printf(
+			'%s %s',
+			$this->render_checkbox( 'activate_content_import' ),
+			$this->render_checkbox_label(
+				'activate_content_import',
+				__( 'Activate the content import functionality', 'multisite-language-switcher' )
+			)
+		);
 	}
 
 	/**
 	 * Show sort_by_description-field
 	 *
-	 * You can decide that the ouput will be sorted by the description. If not
+	 * You can decide that the output will be sorted by the description. If not
 	 * the output will be sorted by the language-code.
 	 */
 	public function sort_by_description() {
-		echo $this->render_checkbox( 'sort_by_description' );
+		printf(
+			'%s %s',
+			$this->render_checkbox( 'sort_by_description' ),
+			$this->render_checkbox_label(
+				'sort_by_description',
+				__( 'Sort languages by description', 'multisite-language-switcher' )
+			)
+		);
 	}
 
 	/**
@@ -415,7 +436,14 @@ class MslsAdmin extends MslsMain {
 	 * plugin will ignore this blog while this option is active.
 	 */
 	public function exclude_current_blog() {
-		echo $this->render_checkbox( 'exclude_current_blog' );
+		printf(
+			'%s %s',
+			$this->render_checkbox( 'exclude_current_blog' ),
+			$this->render_checkbox_label(
+				'exclude_current_blog',
+				__( 'Exclude this blog from output', 'multisite-language-switcher' )
+			)
+		);
 	}
 
 	/**
@@ -425,7 +453,14 @@ class MslsAdmin extends MslsMain {
 	 * translations.
 	 */
 	public function only_with_translation() {
-		echo $this->render_checkbox( 'only_with_translation' );
+		printf(
+			'%s %s',
+			$this->render_checkbox( 'only_with_translation' ),
+			$this->render_checkbox_label(
+				'only_with_translation',
+				__( 'Show only links with a translation', 'multisite-language-switcher' )
+			)
+		);
 	}
 
 	/**
@@ -435,7 +470,14 @@ class MslsAdmin extends MslsMain {
 	 * link to the current blog.
 	 */
 	public function output_current_blog() {
-		echo $this->render_checkbox( 'output_current_blog' );
+		printf(
+			'%s %s',
+			$this->render_checkbox( 'output_current_blog' ),
+			$this->render_checkbox_label(
+				'output_current_blog',
+				__( 'Display link to the current language', 'multisite-language-switcher' )
+			)
+		);
 	}
 
 	/**
@@ -451,7 +493,14 @@ class MslsAdmin extends MslsMain {
 	 * The output can be placed after the_content
 	 */
 	public function content_filter() {
-		echo $this->render_checkbox( 'content_filter' );
+		printf(
+			'%s %s',
+			$this->render_checkbox( 'content_filter' ),
+			$this->render_checkbox_label(
+				'content_filter',
+				__( 'Add hint for available translations', 'multisite-language-switcher' )
+			)
+		);
 	}
 
 	/**
@@ -494,7 +543,7 @@ class MslsAdmin extends MslsMain {
 	/**
 	 * Render form-element (checkbox)
 	 *
-	 * @param string $key Name and ID of the form-element
+	 * @param string $key   Name and ID of the form-element
 	 *
 	 * @return string
 	 */
@@ -503,6 +552,22 @@ class MslsAdmin extends MslsMain {
 			'<input type="checkbox" id="%1$s" name="msls[%1$s]" value="1" %2$s/>',
 			$key,
 			checked( 1, $this->options->$key, false )
+		);
+	}
+
+	/**
+	 * Renders a form checkbox label.
+	 *
+	 * @param string $key   Name and ID of the checkbox.
+	 * @param string $label Label text for the checkbox.
+	 *
+	 * @return string
+	 */
+	public function render_checkbox_label( $key, $label ) {
+		return sprintf(
+			'<label for="%1$s">%2$s</label>',
+			$key,
+			esc_html( $label )
 		);
 	}
 

--- a/tests/test-mslsadmin.php
+++ b/tests/test-mslsadmin.php
@@ -97,7 +97,7 @@ class WP_Test_MslsAdmin extends Msls_UnitTestCase {
 		$this->expectOutputRegex( '/^<select id="blog_language" name="msls\[blog_language\]">.*$/' );
 		$obj->blog_language();
 	}
-	
+
 	/**
 	 * Verify the display-method
 	 */
@@ -124,7 +124,7 @@ class WP_Test_MslsAdmin extends Msls_UnitTestCase {
 	function test_activate_autocomplete() {
 		$obj = $this->get_test();
 
-		$this->expectOutputString( '<input type="checkbox" id="activate_autocomplete" name="msls[activate_autocomplete]" value="1" />' );
+		$this->expectOutputString( '<input type="checkbox" id="activate_autocomplete" name="msls[activate_autocomplete]" value="1" /> <label for="activate_autocomplete">Activate experimental autocomplete inputs</label>' );
 		$obj->activate_autocomplete();
 	}
 
@@ -134,7 +134,7 @@ class WP_Test_MslsAdmin extends Msls_UnitTestCase {
 	function test_sort_by_description() {
 		$obj = $this->get_test();
 
-		$this->expectOutputString( '<input type="checkbox" id="sort_by_description" name="msls[sort_by_description]" value="1" />' );
+		$this->expectOutputString( '<input type="checkbox" id="sort_by_description" name="msls[sort_by_description]" value="1" /> <label for="sort_by_description">Sort languages by description</label>' );
 		$obj->sort_by_description();
 	}
 
@@ -144,7 +144,7 @@ class WP_Test_MslsAdmin extends Msls_UnitTestCase {
 	function test_exclude_current_blog() {
 		$obj = $this->get_test();
 
-		$this->expectOutputString( '<input type="checkbox" id="exclude_current_blog" name="msls[exclude_current_blog]" value="1" />' );
+		$this->expectOutputString( '<input type="checkbox" id="exclude_current_blog" name="msls[exclude_current_blog]" value="1" /> <label for="exclude_current_blog">Exclude this blog from output</label>' );
 		$obj->exclude_current_blog();
 	}
 
@@ -154,7 +154,7 @@ class WP_Test_MslsAdmin extends Msls_UnitTestCase {
 	function test_only_with_translation() {
 		$obj = $this->get_test();
 
-		$this->expectOutputString( '<input type="checkbox" id="only_with_translation" name="msls[only_with_translation]" value="1" />' );
+		$this->expectOutputString( '<input type="checkbox" id="only_with_translation" name="msls[only_with_translation]" value="1" /> <label for="only_with_translation">Show only links with a translation</label>' );
 		$obj->only_with_translation();
 	}
 
@@ -164,7 +164,7 @@ class WP_Test_MslsAdmin extends Msls_UnitTestCase {
 	function test_output_current_blog() {
 		$obj = $this->get_test();
 
-		$this->expectOutputString( '<input type="checkbox" id="output_current_blog" name="msls[output_current_blog]" value="1" />' );
+		$this->expectOutputString( '<input type="checkbox" id="output_current_blog" name="msls[output_current_blog]" value="1" /> <label for="output_current_blog">Display link to the current language</label>' );
 		$obj->output_current_blog();
 	}
 
@@ -184,7 +184,7 @@ class WP_Test_MslsAdmin extends Msls_UnitTestCase {
 	function test_content_filter() {
 		$obj = $this->get_test();
 
-		$this->expectOutputString( '<input type="checkbox" id="content_filter" name="msls[content_filter]" value="1" />' );
+		$this->expectOutputString( '<input type="checkbox" id="content_filter" name="msls[content_filter]" value="1" /> <label for="content_filter">Add hint for available translations</label>' );
 		$obj->content_filter();
 	}
 

--- a/tests/test-mslsadmin.php
+++ b/tests/test-mslsadmin.php
@@ -174,7 +174,7 @@ class WP_Test_MslsAdmin extends Msls_UnitTestCase {
 	function test_description() {
 		$obj = $this->get_test();
 
-		$this->expectOutputString( '<input id="description" name="msls[description]" value="" size="40"/>' );
+		$this->expectOutputString( '<input type="text" class="regular-text" id="description" name="msls[description]" value="" size="40"/>' );
 		$obj->description();
 	}
 


### PR DESCRIPTION
Hello 😄 

I'd like to propose some improvements for the Settings page. Currently, all the labels are not associated with their respective form fields. 

From an accessibility perspective, this causes a few issues:
- Clicking on the label doesn't do anything. Expected: it should focus the associated form control.
- More importantly: screen readers announce the input fields and checkboxes without giving any context: users don't know what the form control refers to

Input with no associated label:

<img width="856" alt="before" src="https://user-images.githubusercontent.com/1682452/56095892-990e1400-5ee1-11e9-9efd-72e506f81eee.png">

Checkbox with no associated label:

<img width="835" alt="checkbox before" src="https://user-images.githubusercontent.com/1682452/56095895-9dd2c800-5ee1-11e9-9db6-ae2ee7c40033.png">

This PR is a first pass tp associate the labels and tries to do the following:

## Input fields (first commit)
Passes the `label_for` param to associate the labels with the input fields. No visual changes. Screenshot:

<img width="847" alt="after" src="https://user-images.githubusercontent.com/1682452/56096049-68c77500-5ee3-11e9-84ab-6345bb2acbde.png">

## Checkboxes (second commit)
Checkboxes are a bit trickier. This is certainly a defect of the WordPress Settings API. There are [various pending Trac tickets related to the Settings API](https://core.trac.wordpress.org/query?keywords=~settings-api) and a couple years ago there was [an attempt to provide default render callbacks to generate the form controls](https://github.com/wpaccessibility/settings-api-enhanced).

Checkbox labels should be on the right of the checkboxes. At the moment, the only way to do this is by  generating the labels via the render callback.

By doing this, the visible text in the table left column is just text, while the real checkbox label is on the right. I do realize this implies visual changes and some adjustments for the text. I'd be glad to implement any feedback to improve the visuals. One option could be to just leave the left table cells empty. Example screenshot:

<img width="835" alt="checkbox after" src="https://user-images.githubusercontent.com/1682452/56096053-71b84680-5ee3-11e9-8782-0e6eb7299ae8.png">

## Other minor changes (third and fourth commits)
- adds `type="text"` to the input fields:
  - properly identifies the input semantics
  - makes the CSS focus style work as expected
- adds the CSS class `regular-text` to the input fields (this is pretty standard in WordPress)
- correct the usage of the buttons CSS classes: the base class `button` should always be used together with modifier classes like `button-primary`. This makes the button have the correct focus style and makes them responsive.

## Add-ons
Lastly, similar changes should be implemented also for the settings section added by `MslsMenu`. However, I'm not sure the version on GitHub (1.4) is the most recent one. Seems to me the one published on the WordPress directory is version 2.0. Glad to propose a PR for `MslsMenu` too, but I'd need some feedback first 🙂 

Thanks for your time and for your great, simple, and powerful plugin!