### PR TITLE
Fix incorrect class name in MslsLink subclass check

### DIFF
--- a/includes/MslsLink.php
+++ b/includes/MslsLink.php
@@ -82,7 +82,7 @@ class MslsLink extends MslsGetSet {
 			 * @return MslsLink
 			 */
 			$obj = apply_filters( 'msls_link_create', $display );
-			if ( is_subclass_of( $obj, 'MslsLink' ) ) {
+			if ( is_subclass_of( $obj, __CLASS__ ) ) {
 				return $obj;
 			}
 		}


### PR DESCRIPTION
`MslsLink` has incorrect class name in subclass check of class returned from `msls_link_create` filter