### PR TITLE
Improvement/emphasize plugin name

### DIFF
--- a/includes/MslsAdmin.php
+++ b/includes/MslsAdmin.php
@@ -114,7 +114,7 @@ class MslsAdmin extends MslsMain {
 
 		if ( $this->options->is_empty() ) {
 			$message = sprintf(
-				__( 'Multisite Language Switcher is almost ready. You must complete the configuration process</a>.' ),
+				__( '<strong>Multisite Language Switcher</strong> is almost ready. You must complete the configuration process</a>.' ),
 				esc_url( admin_url( $this->get_options_page_link() ) )
 			);
 		} elseif ( 1 == count( $this->options->get_available_languages() ) ) {

--- a/includes/MslsPlugin.php
+++ b/includes/MslsPlugin.php
@@ -91,7 +91,7 @@ class MslsPlugin {
 		} else {
 			add_action( 'admin_notices', function () {
 				$href = 'https://wordpress.org/support/article/create-a-network/';
-				$msg  = sprintf( __( 'The Multisite Language Switcher needs the activation of the multisite-feature for working properly. Please read <a onclick="window.open(this.href); return false;" href="%s">this post</a> if you don\'t know the meaning.', 'multisite-language-switcher' ), $href );
+				$msg  = sprintf( __( 'The plugin <strong>Multisite Language Switcher</strong> needs the activation of the multisite-feature for working properly. Please read <a onclick="window.open(this.href); return false;" href="%s">this post</a> if you don\'t know the meaning.', 'multisite-language-switcher' ), $href );
 
 				self::message_handler( $msg );
 			} );


### PR DESCRIPTION
A small change - In the text shown as admin notices on dashboard, the emphasized plugin name would be good as it would be helpful to find in case of so many admin notices available on the screen.

Thank you.