### PR TITLE
Allow x-default hreflang also if multiple alternate links are available

### DIFF
--- a/includes/MslsOutput.php
+++ b/includes/MslsOutput.php
@@ -103,6 +103,7 @@ class MslsOutput extends MslsMain {
 
 		$arr     = [];
 		$default = '';
+        $defaultLocale = apply_filters('mlsl_output_x_default_locale', null);
 
 		foreach ( $blogs->get_objects() as $blog ) {
 			$url = apply_filters( 'mlsl_output_get_alternate_links', $blog->get_url( $options ), $blog );
@@ -114,14 +115,14 @@ class MslsOutput extends MslsMain {
 			$description = $blog->get_description();
 
 			$format = '<link rel="alternate" hreflang="%s" href="%s" title="%s" />';
-			if ( '' === $default ) {
-				$default = sprintf( $format, 'x-default', $url, esc_attr( $description ) );
+            if ( '' === $default || $blog->get_language() === $defaultLocale ) {
+                $default = sprintf( $format, 'x-default', $url, esc_attr( $description ) );
 			}
 
 			$arr[] = sprintf( $format, $hreflang->get( $blog->get_language() ), $url, esc_attr( $description ) );
 		}
 
-		return 1 === count( $arr ) ? $default : implode( PHP_EOL, $arr );
+        return 1 === count( $arr ) ? $default : implode( PHP_EOL, $arr ) . (is_null($defaultLocale) ? '' : $default);
 	}
 
 	/**

--- a/includes/MslsOutput.php
+++ b/includes/MslsOutput.php
@@ -103,7 +103,7 @@ class MslsOutput extends MslsMain {
 
 		$arr     = [];
 		$default = '';
-        $defaultLocale = apply_filters('mlsl_output_x_default_locale', null);
+        $default_locale = apply_filters('mlsl_output_x_default_locale', null);
 
 		foreach ( $blogs->get_objects() as $blog ) {
 			$url = apply_filters( 'mlsl_output_get_alternate_links', $blog->get_url( $options ), $blog );
@@ -115,14 +115,14 @@ class MslsOutput extends MslsMain {
 			$description = $blog->get_description();
 
 			$format = '<link rel="alternate" hreflang="%s" href="%s" title="%s" />';
-            if ( '' === $default || $blog->get_language() === $defaultLocale ) {
+            if ( '' === $default || $blog->get_language() === $default_locale ) {
                 $default = sprintf( $format, 'x-default', $url, esc_attr( $description ) );
 			}
 
 			$arr[] = sprintf( $format, $hreflang->get( $blog->get_language() ), $url, esc_attr( $description ) );
 		}
 
-        return 1 === count( $arr ) ? $default : implode( PHP_EOL, $arr ) . (is_null($defaultLocale) ? '' : $default);
+        return 1 === count( $arr ) ? $default : implode( PHP_EOL, $arr ) . (is_null($default_locale) ? '' : $default);
 	}
 
 	/**


### PR DESCRIPTION
Hey Dennis, 

another filter request:

In your output code, the x-default only gets printed if there is only one alternate-link available. However, when for example offering two options `alternate="de_DE"` and `alternate="en_US"` you still might want to offer an `x-default` for all users from other countries. With this change you can then simply set the following to append the x-default link to the output for the desired default blog:

```
add_filter('mlsl_output_x_default_locale', function ($in) {
    return 'de_DE';
});
```

Will also solve this guys problem https://wordpress.org/support/topic/x-default-hreflang/ ;)

Cheers!