### PR TITLE
ContentImporter - read and set the post type from the request

### DIFF
--- a/includes/ContentImport/ContentImporter.php
+++ b/includes/ContentImport/ContentImporter.php
@@ -4,6 +4,7 @@ namespace lloc\Msls\ContentImport;
 
 use lloc\Msls\ContentImport\Importers\Importer;
 use lloc\Msls\ContentImport\Importers\Map;
+use lloc\Msls\ContentImport\Importers\WithRequestPostAttributes;
 use lloc\Msls\MslsBlogCollection;
 use lloc\Msls\MslsMain;
 use lloc\Msls\MslsOptionsPost;
@@ -17,6 +18,7 @@ use lloc\Msls\MslsRegistryInstance;
  * @package lloc\Msls\ContentImport
  */
 class ContentImporter extends MslsRegistryInstance {
+	use WithRequestPostAttributes;
 
 	/**
 	 * @var MslsMain
@@ -192,7 +194,12 @@ class ContentImporter extends MslsRegistryInstance {
 			return (int) $_REQUEST['post'];
 		}
 
-		return $this->insert_blog_post( $blog_id, [ 'post_title' => 'MSLS Content Import Draft - ' . date( 'Y-m-d H:i:s' ) ] );
+		$data = [
+			'post_type'  => $this->read_post_type_from_request( 'post' ),
+			'post_title' => 'MSLS Content Import Draft - ' . date( 'Y-m-d H:i:s' )
+		];
+
+		return $this->insert_blog_post( $blog_id, $data );
 	}
 
 	protected function insert_blog_post( $blog_id, array $data = [] ) {

--- a/includes/ContentImport/Importers/PostFields/Duplicating.php
+++ b/includes/ContentImport/Importers/PostFields/Duplicating.php
@@ -3,6 +3,7 @@
 namespace lloc\Msls\ContentImport\Importers\PostFields;
 
 use lloc\Msls\ContentImport\Importers\BaseImporter;
+use lloc\Msls\ContentImport\Importers\WithRequestPostAttributes;
 
 /**
  * Class Duplicating
@@ -12,6 +13,7 @@ use lloc\Msls\ContentImport\Importers\BaseImporter;
  * @package lloc\Msls\ContentImport\Importers\PostFields
  */
 class Duplicating extends BaseImporter {
+	use WithRequestPostAttributes;
 
 	const TYPE = 'duplicating';
 
@@ -29,6 +31,9 @@ class Duplicating extends BaseImporter {
 	}
 
 	public function import( array $data ) {
+		// Set the post type reading it from the request payload, if not possible, use the default one.
+		$data['post_type'] = $this->read_post_type_from_request( 'post' );
+
 		$source_post = $this->import_coordinates->source_post;
 
 		foreach ( $this->filter_fields() as $field ) {

--- a/includes/ContentImport/Importers/WithRequestPostAttributes.php
+++ b/includes/ContentImport/Importers/WithRequestPostAttributes.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Provides methods to parse and get information about the post object of the import from
+ * the request parameters.
+ *
+ * @since   TBD
+ *
+ * @package lloc\Msls\ContentImport\Importers
+ */
+
+namespace lloc\Msls\ContentImport\Importers;
+
+/**
+ * Trait WithRequestPostAttributes
+ *
+ * @since   TBD
+ *
+ * @package lloc\Msls\ContentImport\Importers
+ */
+trait WithRequestPostAttributes {
+	/**
+	 * Returns the post type read from `$_REQUEST['post_type']` if any, or a default post type.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $default The default post type to return if none is specified in the `$_REQUEST` super-global.
+	 *
+	 * @return string Either the post type read from the `$_REQUEST` super-global, or the default value.
+	 */
+	protected function read_post_type_from_request( $default = 'post' ) {
+		if ( ! isset( $_REQUEST['post_type'] ) ) {
+			return $default;
+		}
+
+		return filter_var( $_REQUEST['post_type'], FILTER_SANITIZE_STRING ) ?: 'post';
+	}
+}


### PR DESCRIPTION
@lloc this PR fixes the issue where duplicating a post using the Content Importer would incorrectly set its post type to `post`.

The fix consists in reading the current post type from the request and defaulting to the `post` post type if not found.

> Note: I've tried to run the tests and could not run the ones in the `legacy-tests` directory. Is there any way to do that?

The code I'm fixing in this PR is covered there and I would like to add coverage for those, let me know.