### PR TITLE
Fix #184 - use type of post and not only request

### DIFF
--- a/includes/MslsAdminIcon.php
+++ b/includes/MslsAdminIcon.php
@@ -90,10 +90,12 @@ class MslsAdminIcon {
 	 *
 	 * @return MslsAdminIcon
 	 */
-	public static function create() {
+	public static function create($type = null) {
 		$obj = MslsContentTypes::create();
 
-		$type = $obj->get_request();
+		if(!$type) {
+            $type = $obj->get_request();
+        }
 		if ( $obj->is_taxonomy() ) {
 			return new MslsAdminIconTaxonomy( $type );
 		}

--- a/includes/MslsMetaBox.php
+++ b/includes/MslsMetaBox.php
@@ -183,7 +183,7 @@ class MslsMetaBox extends MslsMain {
 				switch_to_blog( $blog->userblog_id );
 
 				$language = $blog->get_language();
-				$icon     = MslsAdminIcon::create()
+				$icon     = MslsAdminIcon::create( $type )
 				                         ->set_language( $language )
 				                         ->set_icon_type( 'flag' );
 


### PR DESCRIPTION
When the icon for creating new posts in the metabox is created, the real post type is not used, but only the post type from the request.

This commit fixes this - the icon will now use the post type regardless if it is a new post or editing an exiting post.