### PR TITLE
Fix for creating terms on the overview page.

### DIFF
--- a/includes/MslsPlugin.php
+++ b/includes/MslsPlugin.php
@@ -69,7 +69,7 @@ class MslsPlugin {
 				add_action( 'load-term.php', array( MslsPostTag::class, 'init' ) );
 
 				if ( MslsRequest::has_var( MslsFields::FIELD_ACTION ) ) {
-					$action = MslsRequest::has_var( MslsFields::FIELD_ACTION );
+					$action = MslsRequest::get_var( MslsFields::FIELD_ACTION );
 
 					if ( 'add-tag' === $action ) {
 						add_action( 'admin_init', array( MslsPostTag::class, 'init' ) );


### PR DESCRIPTION
Hey!

I realized, that the actions in MslsPlugin wheren't firing, because the $action name is never used, but only if one is set. So the subsequent adding of the necessary actions to save the linked terms is never executed.

Simple fix, just replaced has_var with get_var - quick and simple.

Best
Philipp