### PR TITLE
Add filter hooks for AJAX suggest results

### DIFF
--- a/includes/MslsFields.php
+++ b/includes/MslsFields.php
@@ -15,6 +15,7 @@ class MslsFields {
 	const FIELD_MSLS_LANG      = 'msls_lang';
 	const FIELD_MSLS_IMPORT    = 'msls_import';
 	const FIELD_POST           = 'post';
+	const FIELD_SOURCE_ID      = 'source_id';
 
 	const CONFIG = array(
 		self::FIELD_BLOG_ID        => array(
@@ -59,6 +60,10 @@ class MslsFields {
 		),
 		self::FIELD_POST           => array(
 			INPUT_GET,
+			FILTER_SANITIZE_NUMBER_INT,
+		),
+		self::FIELD_SOURCE_ID      => array(
+			INPUT_POST,
 			FILTER_SANITIZE_NUMBER_INT,
 		),
 	);

--- a/includes/MslsMetaBox.php
+++ b/includes/MslsMetaBox.php
@@ -68,8 +68,27 @@ final class MslsMetaBox extends MslsMain {
 			restore_current_blog();
 		}
 
-        // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-		wp_die( $json->encode() );
+		/**
+		 * Filters the suggest results before encoding
+		 *
+		 * @param array<int, array{value: int, label: string}> $results
+		 * @param array<string, mixed> $context
+		 *
+		 * @since 2.12.0
+		 */
+		$results = (array) apply_filters(
+			'msls_meta_box_suggest_results',
+			$json->get(),
+			array(
+				'blog_id'   => MslsRequest::get_var( MslsFields::FIELD_BLOG_ID, INPUT_POST ),
+				'post_type' => MslsRequest::get_var( MslsFields::FIELD_POST_TYPE, INPUT_POST ),
+				's'         => MslsRequest::get_var( MslsFields::FIELD_S, INPUT_POST ),
+				'source_id' => MslsRequest::get_var( MslsFields::FIELD_SOURCE_ID, INPUT_POST ),
+			)
+		);
+
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		wp_die( wp_json_encode( $results ) );
 	}
 
 	/**
@@ -332,9 +351,10 @@ final class MslsMetaBox extends MslsMain {
 
 			echo wp_kses(
 				sprintf(
-					'<ul>%s</ul><input type="hidden" name="msls_post_type" id="msls_post_type" value="%s"/><input type="hidden" name="msls_action" id="msls_action" value="suggest_posts"/>',
+					'<ul>%s</ul><input type="hidden" name="msls_post_type" id="msls_post_type" value="%s"/><input type="hidden" name="msls_action" id="msls_action" value="suggest_posts"/><input type="hidden" name="msls_source_id" id="msls_source_id" value="%d"/>',
 					$items,
-					$post_type
+					$post_type,
+					$post->ID
 				),
 				Component::get_allowed_html()
 			);

--- a/includes/MslsPostTag.php
+++ b/includes/MslsPostTag.php
@@ -72,7 +72,26 @@ class MslsPostTag extends MslsMain {
 			restore_current_blog();
 		}
 
-		wp_die( $json->encode() ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		/**
+		 * Filters the suggest results before encoding
+		 *
+		 * @param array<int, array{value: int, label: string}> $results
+		 * @param array<string, mixed> $context
+		 *
+		 * @since 2.12.0
+		 */
+		$results = (array) apply_filters(
+			'msls_post_tag_suggest_results',
+			$json->get(),
+			array(
+				'blog_id'   => MslsRequest::get_var( MslsFields::FIELD_BLOG_ID ),
+				'taxonomy'  => MslsRequest::get_var( MslsFields::FIELD_POST_TYPE ),
+				's'         => MslsRequest::get_var( MslsFields::FIELD_S ),
+				'source_id' => MslsRequest::get_var( MslsFields::FIELD_SOURCE_ID ),
+			)
+		);
+
+		wp_die( wp_json_encode( $results ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
 
 	public static function init(): void {
@@ -102,7 +121,8 @@ class MslsPostTag extends MslsMain {
 
 		$title_format = '<h3>%s</h3>
 			<input type="hidden" name="msls_post_type" id="msls_post_type" value="%s"/>
-			<input type="hidden" name="msls_action" id="msls_action" value="suggest_terms"/>';
+			<input type="hidden" name="msls_action" id="msls_action" value="suggest_terms"/>
+			<input type="hidden" name="msls_source_id" id="msls_source_id" value="%d"/>';
 
 		$item_format = '<label for="msls_title_%1$d">%2$s</label>
 			<input type="hidden" id="msls_id_%1$d" name="msls_input_%3$s" value="%4$s"/>
@@ -131,6 +151,7 @@ class MslsPostTag extends MslsMain {
 			<strong>%s</strong>
 			<input type="hidden" name="msls_post_type" id="msls_post_type" value="%s"/>
 			<input type="hidden" name="msls_action" id="msls_action" value="suggest_terms"/>
+			<input type="hidden" name="msls_source_id" id="msls_source_id" value="%d"/>
 			</th>
 			</tr>';
 
@@ -172,7 +193,7 @@ class MslsPostTag extends MslsMain {
 			$allowed_html = Component::get_allowed_html();
 
 			echo wp_kses(
-				sprintf( $title_format, esc_html( $this->get_select_title() ), esc_attr( $type ) ),
+				sprintf( $title_format, esc_html( $this->get_select_title() ), esc_attr( $type ), $term_id ),
 				$allowed_html
 			);
 

--- a/src/msls.js
+++ b/src/msls.js
@@ -19,7 +19,8 @@ jQuery( document ).ready(
 										post_type: $( '#msls_post_type' ).val(),
 										blog_id: blog_id,
 										s: request.term,
-										action: $( '#msls_action' ).val()
+										action: $( '#msls_action' ).val(),
+									source_id: $( '#msls_source_id' ).val() || 0
 									},
 									dataType: 'JSON',
 									type: 'POST',

--- a/tests/phpunit/TestMslsMetaBox.php
+++ b/tests/phpunit/TestMslsMetaBox.php
@@ -4,6 +4,7 @@ namespace lloc\MslsTests;
 
 use Brain\Monkey\Functions;
 use Brain\Monkey\Actions;
+use Brain\Monkey\Filters;
 
 use lloc\Msls\MslsBlog;
 use lloc\Msls\MslsBlogCollection;
@@ -71,6 +72,43 @@ final class TestMslsMetaBox extends MslsUnitTestCase {
 		Functions\when( 'wp_die' )->justEcho( $json );
 
 		$this->expectOutputString( '{"some":"JSON"}' );
+
+		MslsMetaBox::suggest();
+	}
+
+	public function test_suggest_applies_results_filter(): void {
+		$post     = \Mockery::mock( 'WP_Post' );
+		$post->ID = 42;
+
+		Functions\expect( 'filter_has_var' )->times( 3 )->andReturnTrue();
+		Functions\expect( 'filter_input' )->once()->with( INPUT_POST, MslsFields::FIELD_BLOG_ID, FILTER_SANITIZE_NUMBER_INT )->andReturn( 2 );
+		Functions\expect( 'filter_input' )->once()->with( INPUT_POST, MslsFields::FIELD_POST_TYPE, FILTER_SANITIZE_FULL_SPECIAL_CHARS )->andReturn( 'post' );
+		Functions\expect( 'filter_input' )->once()->with( INPUT_POST, MslsFields::FIELD_S, FILTER_SANITIZE_FULL_SPECIAL_CHARS )->andReturn( 'test' );
+		Functions\expect( 'filter_input' )->once()->with( INPUT_POST, MslsFields::FIELD_SOURCE_ID, FILTER_SANITIZE_NUMBER_INT )->andReturn( 99 );
+		Functions\expect( 'get_post_stati' )->once()->andReturn( array( 'pending', 'draft', 'future' ) );
+		Functions\expect( 'get_the_title' )->once()->andReturn( 'Test Post' );
+		Functions\expect( 'get_posts' )->once()->andReturn( array( $post ) );
+		Functions\expect( 'switch_to_blog' )->once();
+		Functions\expect( 'restore_current_blog' )->once();
+		Functions\expect( 'wp_reset_postdata' )->once();
+		Functions\expect( 'wp_json_encode' )->once()->andReturnUsing( 'json_encode' );
+		Functions\expect( 'wp_die' )->once()->andReturnUsing(
+			function ( $output ) {
+				echo $output;
+			}
+		);
+
+		Filters\expectApplied( 'msls_meta_box_suggest_results' )->once()->with(
+			array(
+				array(
+					'value' => 42,
+					'label' => 'Test Post',
+				),
+			),
+			\Mockery::type( 'array' )
+		);
+
+		$this->expectOutputString( '[{"value":42,"label":"Test Post"}]' );
 
 		MslsMetaBox::suggest();
 	}

--- a/tests/phpunit/TestMslsMetaBox.php
+++ b/tests/phpunit/TestMslsMetaBox.php
@@ -53,25 +53,29 @@ final class TestMslsMetaBox extends MslsUnitTestCase {
 	}
 
 	public function test_suggest(): void {
-		$json = '{"some":"JSON"}';
-
 		$post     = \Mockery::mock( 'WP_Post' );
 		$post->ID = 42;
 
 		Functions\expect( 'filter_has_var' )->times( 3 )->andReturnTrue();
-		Functions\expect( 'filter_input' )->once()->with( INPUT_POST, MslsFields::FIELD_BLOG_ID, FILTER_SANITIZE_NUMBER_INT )->andReturn( 17 );
-		Functions\expect( 'filter_input' )->once()->with( INPUT_POST, MslsFields::FIELD_POST_TYPE, FILTER_SANITIZE_FULL_SPECIAL_CHARS )->andReturn( 17 );
-		Functions\expect( 'filter_input' )->once()->with( INPUT_POST, MslsFields::FIELD_S, FILTER_SANITIZE_FULL_SPECIAL_CHARS )->andReturn( 17 );
+		Functions\expect( 'filter_input' )->twice()->with( INPUT_POST, MslsFields::FIELD_BLOG_ID, FILTER_SANITIZE_NUMBER_INT )->andReturn( 17 );
+		Functions\expect( 'filter_input' )->twice()->with( INPUT_POST, MslsFields::FIELD_POST_TYPE, FILTER_SANITIZE_FULL_SPECIAL_CHARS )->andReturn( 17 );
+		Functions\expect( 'filter_input' )->twice()->with( INPUT_POST, MslsFields::FIELD_S, FILTER_SANITIZE_FULL_SPECIAL_CHARS )->andReturn( 17 );
+		Functions\expect( 'filter_input' )->once()->with( INPUT_POST, MslsFields::FIELD_SOURCE_ID, FILTER_SANITIZE_NUMBER_INT )->andReturn( 0 );
 		Functions\expect( 'get_post_stati' )->once()->andReturn( array( 'pending', 'draft', 'future' ) );
 		Functions\expect( 'get_the_title' )->once()->andReturn( 'Test' );
 		Functions\expect( 'get_posts' )->once()->andReturn( array( $post ) );
 		Functions\expect( 'switch_to_blog' )->once();
 		Functions\expect( 'restore_current_blog' )->once();
 		Functions\expect( 'wp_reset_postdata' )->once();
+		Functions\expect( 'wp_json_encode' )->once()->andReturnUsing( 'json_encode' );
 
-		Functions\when( 'wp_die' )->justEcho( $json );
+		Functions\expect( 'wp_die' )->once()->andReturnUsing(
+			function ( $output ) {
+				echo $output;
+			}
+		);
 
-		$this->expectOutputString( '{"some":"JSON"}' );
+		$this->expectOutputString( '[{"value":42,"label":"Test"}]' );
 
 		MslsMetaBox::suggest();
 	}
@@ -81,9 +85,9 @@ final class TestMslsMetaBox extends MslsUnitTestCase {
 		$post->ID = 42;
 
 		Functions\expect( 'filter_has_var' )->times( 3 )->andReturnTrue();
-		Functions\expect( 'filter_input' )->once()->with( INPUT_POST, MslsFields::FIELD_BLOG_ID, FILTER_SANITIZE_NUMBER_INT )->andReturn( 2 );
-		Functions\expect( 'filter_input' )->once()->with( INPUT_POST, MslsFields::FIELD_POST_TYPE, FILTER_SANITIZE_FULL_SPECIAL_CHARS )->andReturn( 'post' );
-		Functions\expect( 'filter_input' )->once()->with( INPUT_POST, MslsFields::FIELD_S, FILTER_SANITIZE_FULL_SPECIAL_CHARS )->andReturn( 'test' );
+		Functions\expect( 'filter_input' )->twice()->with( INPUT_POST, MslsFields::FIELD_BLOG_ID, FILTER_SANITIZE_NUMBER_INT )->andReturn( 2 );
+		Functions\expect( 'filter_input' )->twice()->with( INPUT_POST, MslsFields::FIELD_POST_TYPE, FILTER_SANITIZE_FULL_SPECIAL_CHARS )->andReturn( 'post' );
+		Functions\expect( 'filter_input' )->twice()->with( INPUT_POST, MslsFields::FIELD_S, FILTER_SANITIZE_FULL_SPECIAL_CHARS )->andReturn( 'test' );
 		Functions\expect( 'filter_input' )->once()->with( INPUT_POST, MslsFields::FIELD_SOURCE_ID, FILTER_SANITIZE_NUMBER_INT )->andReturn( 99 );
 		Functions\expect( 'get_post_stati' )->once()->andReturn( array( 'pending', 'draft', 'future' ) );
 		Functions\expect( 'get_the_title' )->once()->andReturn( 'Test Post' );
@@ -246,8 +250,8 @@ final class TestMslsMetaBox extends MslsUnitTestCase {
 
 	public static function render_input_provider(): array {
 		return array(
-			array( array( 'de_DE' => 42 ), 1, 0, 0, 1, '<ul><li class=""><label for="msls_title_ msls-icon-wrapper flag"><a title="Edit the translation in the de_DE-blog" href="edit-post-link"><span class="flag-icon flag-icon-de">de_DE</span></a>&nbsp;</label><input type="hidden" id="msls_id_" name="msls_input_de_DE" value="42"/><input class="msls_title" id="msls_title_" name="msls_title_" type="text" value="Test"/></li></ul><input type="hidden" name="msls_post_type" id="msls_post_type" value="page"/><input type="hidden" name="msls_action" id="msls_action" value="suggest_posts"/>' ),
-			array( array( 'en_US' => 17 ), 0, 1, 1, 0, '<ul><li class=""><label for="msls_title_ msls-icon-wrapper flag"><a title="Create a new translation in the de_DE-blog" href="admin-url-empty"><span class="flag-icon flag-icon-de">de_DE</span></a>&nbsp;</label><input type="hidden" id="msls_id_" name="msls_input_de_DE" value=""/><input class="msls_title" id="msls_title_" name="msls_title_" type="text" value=""/></li></ul><input type="hidden" name="msls_post_type" id="msls_post_type" value="page"/><input type="hidden" name="msls_action" id="msls_action" value="suggest_posts"/>' ),
+			array( array( 'de_DE' => 42 ), 1, 0, 0, 1, '<ul><li class=""><label for="msls_title_ msls-icon-wrapper flag"><a title="Edit the translation in the de_DE-blog" href="edit-post-link"><span class="flag-icon flag-icon-de">de_DE</span></a>&nbsp;</label><input type="hidden" id="msls_id_" name="msls_input_de_DE" value="42"/><input class="msls_title" id="msls_title_" name="msls_title_" type="text" value="Test"/></li></ul><input type="hidden" name="msls_post_type" id="msls_post_type" value="page"/><input type="hidden" name="msls_action" id="msls_action" value="suggest_posts"/><input type="hidden" name="msls_source_id" id="msls_source_id" value="42"/>' ),
+			array( array( 'en_US' => 17 ), 0, 1, 1, 0, '<ul><li class=""><label for="msls_title_ msls-icon-wrapper flag"><a title="Create a new translation in the de_DE-blog" href="admin-url-empty"><span class="flag-icon flag-icon-de">de_DE</span></a>&nbsp;</label><input type="hidden" id="msls_id_" name="msls_input_de_DE" value=""/><input class="msls_title" id="msls_title_" name="msls_title_" type="text" value=""/></li></ul><input type="hidden" name="msls_post_type" id="msls_post_type" value="page"/><input type="hidden" name="msls_action" id="msls_action" value="suggest_posts"/><input type="hidden" name="msls_source_id" id="msls_source_id" value="42"/>' ),
 		);
 	}
 

--- a/tests/phpunit/TestMslsPostTag.php
+++ b/tests/phpunit/TestMslsPostTag.php
@@ -4,8 +4,10 @@ namespace lloc\MslsTests;
 
 use Brain\Monkey\Functions;
 use Brain\Monkey\Actions;
+use Brain\Monkey\Filters;
 use lloc\Msls\MslsBlog;
 use lloc\Msls\MslsBlogCollection;
+use lloc\Msls\MslsFields;
 use lloc\Msls\MslsOptions;
 use lloc\Msls\MslsOptionsTax;
 use lloc\Msls\MslsPostTag;
@@ -79,6 +81,41 @@ final class TestMslsPostTag extends MslsUnitTestCase {
 		Functions\expect( 'get_terms' )->atLeast()->once()->andReturn( array( $term ) );
 
 		self::expectOutputString( '' );
+
+		MslsPostTag::suggest();
+	}
+
+	public function test_suggest_applies_results_filter(): void {
+		$term          = \Mockery::mock( \WP_Term::class );
+		$term->term_id = 42;
+		$term->name    = 'Test Term';
+
+		Functions\expect( 'filter_has_var' )->atLeast()->once()->andReturnTrue();
+		Functions\expect( 'filter_input' )->once()->with( INPUT_POST, MslsFields::FIELD_BLOG_ID, FILTER_SANITIZE_NUMBER_INT )->andReturn( 2 );
+		Functions\expect( 'filter_input' )->once()->with( INPUT_POST, MslsFields::FIELD_POST_TYPE, FILTER_SANITIZE_FULL_SPECIAL_CHARS )->andReturn( 'post_tag' );
+		Functions\expect( 'filter_input' )->once()->with( INPUT_POST, MslsFields::FIELD_S, FILTER_SANITIZE_FULL_SPECIAL_CHARS )->andReturn( 'test' );
+		Functions\expect( 'filter_input' )->once()->with( INPUT_POST, MslsFields::FIELD_SOURCE_ID, FILTER_SANITIZE_NUMBER_INT )->andReturn( 99 );
+		Functions\expect( 'switch_to_blog' )->once();
+		Functions\expect( 'restore_current_blog' )->once();
+		Functions\expect( 'get_terms' )->once()->andReturn( array( $term ) );
+		Functions\expect( 'wp_json_encode' )->once()->andReturnUsing( 'json_encode' );
+		Functions\expect( 'wp_die' )->once()->andReturnUsing(
+			function ( $output ) {
+				echo $output;
+			}
+		);
+
+		Filters\expectApplied( 'msls_post_tag_suggest_results' )->once()->with(
+			array(
+				array(
+					'value' => 42,
+					'label' => 'Test Term',
+				),
+			),
+			\Mockery::type( 'array' )
+		);
+
+		$this->expectOutputString( '[{"value":42,"label":"Test Term"}]' );
 
 		MslsPostTag::suggest();
 	}

--- a/tests/phpunit/TestMslsPostTag.php
+++ b/tests/phpunit/TestMslsPostTag.php
@@ -145,6 +145,7 @@ final class TestMslsPostTag extends MslsUnitTestCase {
 			<strong>Multisite Language Switcher</strong>
 			<input type="hidden" name="msls_post_type" id="msls_post_type" value="post"/>
 			<input type="hidden" name="msls_action" id="msls_action" value="suggest_terms"/>
+			<input type="hidden" name="msls_source_id" id="msls_source_id" value="0"/>
 			</th>
 			</tr><tr class="form-field">
 			<th scope="row">
@@ -193,7 +194,8 @@ final class TestMslsPostTag extends MslsUnitTestCase {
 
 		$output = '<div class="form-field"><h3>Multisite Language Switcher</h3>
 			<input type="hidden" name="msls_post_type" id="msls_post_type" value="post"/>
-			<input type="hidden" name="msls_action" id="msls_action" value="suggest_terms"/><label for="msls_title_0"><a title="Create a new translation in the de_DE-blog" href="/wp-admin/edit-tags.php"><span class="language-badge de_DE"><span>de</span><span>DE</span></span></a>&nbsp;</label>
+			<input type="hidden" name="msls_action" id="msls_action" value="suggest_terms"/>
+			<input type="hidden" name="msls_source_id" id="msls_source_id" value="0"/><label for="msls_title_0"><a title="Create a new translation in the de_DE-blog" href="/wp-admin/edit-tags.php"><span class="language-badge de_DE"><span>de</span><span>DE</span></span></a>&nbsp;</label>
 			<input type="hidden" id="msls_id_0" name="msls_input_de_DE" value=""/>
 			<input class="msls_title" id="msls_title_0" name="msls_title_0" type="text" value=""/><label for="msls_title_0"><a title="Create a new translation in the en_US-blog" href="/wp-admin/edit-tags.php"><span class="language-badge en_US"><span>en</span><span>US</span></span></a>&nbsp;</label>
 			<input type="hidden" id="msls_id_0" name="msls_input_en_US" value=""/>

--- a/tests/phpunit/TestMslsPostTag.php
+++ b/tests/phpunit/TestMslsPostTag.php
@@ -91,9 +91,9 @@ final class TestMslsPostTag extends MslsUnitTestCase {
 		$term->name    = 'Test Term';
 
 		Functions\expect( 'filter_has_var' )->atLeast()->once()->andReturnTrue();
-		Functions\expect( 'filter_input' )->once()->with( INPUT_POST, MslsFields::FIELD_BLOG_ID, FILTER_SANITIZE_NUMBER_INT )->andReturn( 2 );
-		Functions\expect( 'filter_input' )->once()->with( INPUT_POST, MslsFields::FIELD_POST_TYPE, FILTER_SANITIZE_FULL_SPECIAL_CHARS )->andReturn( 'post_tag' );
-		Functions\expect( 'filter_input' )->once()->with( INPUT_POST, MslsFields::FIELD_S, FILTER_SANITIZE_FULL_SPECIAL_CHARS )->andReturn( 'test' );
+		Functions\expect( 'filter_input' )->twice()->with( INPUT_POST, MslsFields::FIELD_BLOG_ID, FILTER_SANITIZE_NUMBER_INT )->andReturn( 2 );
+		Functions\expect( 'filter_input' )->twice()->with( INPUT_POST, MslsFields::FIELD_POST_TYPE, FILTER_SANITIZE_FULL_SPECIAL_CHARS )->andReturn( 'post_tag' );
+		Functions\expect( 'filter_input' )->twice()->with( INPUT_POST, MslsFields::FIELD_S, FILTER_SANITIZE_FULL_SPECIAL_CHARS )->andReturn( 'test' );
 		Functions\expect( 'filter_input' )->once()->with( INPUT_POST, MslsFields::FIELD_SOURCE_ID, FILTER_SANITIZE_NUMBER_INT )->andReturn( 99 );
 		Functions\expect( 'switch_to_blog' )->once();
 		Functions\expect( 'restore_current_blog' )->once();


### PR DESCRIPTION
## Summary

- Add `msls_meta_box_suggest_results` and `msls_post_tag_suggest_results` filters on the final suggest results array, enabling add-on plugins to re-sort, relabel, insert spacers, or reorder translation candidates
- Pass `source_id` (the post/term being edited) through JS AJAX request and into the filter context, so consumers can implement heuristic matching
- New `FIELD_SOURCE_ID` constant in `MslsFields` with hidden field in both post metabox and term input templates

Closes #604

## Test plan

- [x] All 400 existing tests pass
- [x] New tests verify both filters are applied with correct context
- [x] Manual: hook into `msls_meta_box_suggest_results`, confirm modified results appear in autocomplete dropdown