### PR TITLE
Fix ContentImporter permission and post type checks

### DIFF
--- a/includes/ContentImport/ContentImporter.php
+++ b/includes/ContentImport/ContentImporter.php
@@ -242,6 +242,12 @@ class ContentImporter extends MslsRegistryInstance {
 
 		switch_to_blog( $blog_id );
 
+		if ( ! empty( $data['post_type'] ) && ! post_type_exists( $data['post_type'] ) ) {
+			restore_current_blog();
+
+			return false;
+		}
+
 		$this->handle( false );
 		if ( isset( $data['ID'] ) ) {
 			$post_id = wp_update_post( $data );

--- a/includes/ContentImport/ContentImporter.php
+++ b/includes/ContentImport/ContentImporter.php
@@ -110,6 +110,14 @@ class ContentImporter extends MslsRegistryInstance {
 			return $data;
 		}
 
+		switch_to_blog( $source_blog_id );
+		$can_read = current_user_can( 'read_post', $source_post_id );
+		restore_current_blog();
+
+		if ( ! $can_read ) {
+			return $data;
+		}
+
 		$source_lang  = MslsBlogCollection::get_blog_language( $source_blog_id );
 		$dest_blog_id = get_current_blog_id();
 		$dest_lang    = MslsBlogCollection::get_blog_language( get_current_blog_id() );

--- a/includes/ContentImport/ContentImporter.php
+++ b/includes/ContentImport/ContentImporter.php
@@ -111,10 +111,11 @@ class ContentImporter extends MslsRegistryInstance {
 		}
 
 		switch_to_blog( $source_blog_id );
-		$can_read = current_user_can( 'read_post', $source_post_id );
+		$can_read    = current_user_can( 'read_post', $source_post_id );
+		$source_post = get_post( $source_post_id );
 		restore_current_blog();
 
-		if ( ! $can_read ) {
+		if ( ! $can_read || ! $source_post instanceof \WP_Post ) {
 			return $data;
 		}
 
@@ -125,14 +126,6 @@ class ContentImporter extends MslsRegistryInstance {
 		$dest_post_id = $this->get_the_blog_post_ID( $dest_blog_id );
 
 		if ( empty( $dest_post_id ) ) {
-			return $data;
-		}
-
-		switch_to_blog( $source_blog_id );
-		$source_post = get_post( $source_post_id );
-		restore_current_blog();
-
-		if ( ! $source_post instanceof \WP_Post ) {
 			return $data;
 		}
 


### PR DESCRIPTION
Closes #610, closes #611

## Summary

- Add `read_post` capability check on the source blog before importing content, preventing private content from leaking across blogs
- Add `post_type_exists()` check on the target blog before inserting, preventing silent failures when a custom post type is not registered on all blogs

## Test plan

- [ ] Attempt content import from a private post the user cannot read — should silently skip
- [ ] Attempt content import to a blog missing the source post type — should silently skip
- [ ] Normal content import workflow still works as before
- [ ] Run `composer test` — all tests pass