### PR TITLE
Emit hreflang x-default when more than one translation exists

### DIFF
--- a/includes/MslsOutput.php
+++ b/includes/MslsOutput.php
@@ -138,6 +138,10 @@ class MslsOutput extends MslsMain {
 			return apply_filters( self::MSLS_ALTERNATE_LINKS_DEFAULT_HOOK, $default );
 		}
 
+		if ( empty( $arr ) ) {
+			return '';
+		}
+
 		$default = apply_filters( self::MSLS_ALTERNATE_LINKS_DEFAULT_HOOK, $default );
 		if ( '' !== $default ) {
 			array_unshift( $arr, $default );

--- a/includes/MslsOutput.php
+++ b/includes/MslsOutput.php
@@ -138,6 +138,11 @@ class MslsOutput extends MslsMain {
 			return apply_filters( self::MSLS_ALTERNATE_LINKS_DEFAULT_HOOK, $default );
 		}
 
+		$default = apply_filters( self::MSLS_ALTERNATE_LINKS_DEFAULT_HOOK, $default );
+		if ( '' !== $default ) {
+			array_unshift( $arr, $default );
+		}
+
 		$arr = (array) apply_filters( self::MSLS_ALTERNATE_LINKS_ARR_HOOK, $arr );
 
 		return implode( PHP_EOL, $arr );

--- a/tests/phpunit/TestMslsOutput.php
+++ b/tests/phpunit/TestMslsOutput.php
@@ -65,6 +65,57 @@ final class TestMslsOutput extends MslsUnitTestCase {
 		Functions\expect( 'get_queried_object_id' )->once()->andReturn( 42 );
 		Functions\expect( 'get_option' )->once()->andReturn( array() );
 
+		Filters\expectApplied( 'msls_output_get_alternate_links_default' )->once();
+		Filters\expectApplied( 'msls_output_get_alternate_links_arr' )->once();
+
+		$expected =
+			'<link rel="alternate" href="https://example.de/" hreflang="x-default" />' . PHP_EOL .
+			'<link rel="alternate" href="https://example.de/" hreflang="de" />' . PHP_EOL .
+			'<link rel="alternate" href="https://example.it/" hreflang="it" />';
+
+		$test = $this->MslsOutputFactory();
+
+		$this->assertEquals( $expected, $test->get_alternate_links() );
+	}
+
+	public function test_get_alternate_links_x_default_suppressed(): void {
+		$blogs = array();
+
+		$a = \Mockery::mock( MslsBlog::class );
+		$a->shouldReceive( 'get_alpha2' )->andReturn( 'de' );
+		$a->shouldReceive( 'get_language' )->andReturn( 'de_DE' );
+		$a->shouldReceive( 'get_url' )->andReturn( 'https://example.de/' );
+		$a->shouldReceive( 'get_description' )->andReturn( 'Deutsch' );
+
+		$blogs[] = $a;
+
+		$b = \Mockery::mock( MslsBlog::class );
+		$b->shouldReceive( 'get_alpha2' )->andReturn( 'it' );
+		$b->shouldReceive( 'get_language' )->andReturn( 'it_IT' );
+		$b->shouldReceive( 'get_url' )->andReturn( 'https://example.it/' );
+		$b->shouldReceive( 'get_description' )->andReturn( 'Italiano' );
+
+		$blogs[] = $b;
+
+		$collection = \Mockery::mock( MslsBlogCollection::class );
+		$collection->shouldReceive( 'get_objects' )->andReturn( $blogs );
+
+		Functions\expect( 'msls_blog_collection' )->once()->andReturn( $collection );
+		Functions\expect( 'is_admin' )->once()->andReturn( false );
+		Functions\expect( 'is_front_page' )->once()->andReturn( false );
+		Functions\expect( 'is_search' )->once()->andReturn( false );
+		Functions\expect( 'is_404' )->once()->andReturn( false );
+		Functions\expect( 'is_category' )->once()->andReturn( false );
+		Functions\expect( 'is_tag' )->once()->andReturn( false );
+		Functions\expect( 'is_tax' )->once()->andReturn( false );
+		Functions\expect( 'is_date' )->once()->andReturn( false );
+		Functions\expect( 'is_author' )->once()->andReturn( false );
+		Functions\expect( 'is_post_type_archive' )->once()->andReturn( false );
+		Functions\expect( 'get_queried_object_id' )->once()->andReturn( 42 );
+		Functions\expect( 'get_option' )->once()->andReturn( array() );
+
+		// Returning an empty string from the filter opts out of x-default.
+		Filters\expectApplied( 'msls_output_get_alternate_links_default' )->once()->andReturn( '' );
 		Filters\expectApplied( 'msls_output_get_alternate_links_arr' )->once();
 
 		$expected =


### PR DESCRIPTION
Closes #640.

## What

`MslsOutput::get_alternate_links()` only emitted an `hreflang="x-default"` alternate when a
**single** translation existed. With two or more translations — the normal multilingual case —
x-default was dropped and only language-specific alternates were returned.

`x-default` is the fallback search engines use when no other `hreflang` matches the visitor's
locale; Google and the W3C recommend it for multilingual pages. This emits it in the
multi-alternate case too.

## How

- In the multi-alternate branch, run the already-computed `$default` through the existing
  `msls_output_get_alternate_links_default` filter and prepend it to the alternates.
- Returning `''` from that filter suppresses x-default (opt-out). Single-translation behaviour
  is unchanged.

## Tests

- Updated `test_get_alternate_links_two_url` to assert the x-default alternate is present.
- Added `test_get_alternate_links_x_default_suppressed` covering the empty-string opt-out.
- `phpunit` green, `phpcs` (PHPCompatibility) clean, `phpstan` reports no new errors in
  `MslsOutput`.

## Refs

- Google Search Central — Localized versions: https://developers.google.com/search/docs/specialized/international/localized-versions
- Website specification — hreflang: https://specification.website/spec/i18n/hreflang/
