### PR TITLE
feat: make msls_get_switcher() $attr optional

### DIFF
--- a/includes/api.php
+++ b/includes/api.php
@@ -10,10 +10,11 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Get the output for using the links to the translations in your code
  *
  * @package Msls
- * @param mixed $attr
+ * @since 3.0.0 The $attr parameter is optional and defaults to an empty array.
+ * @param mixed $attr Optional. Attributes forwarded to the switcher output. Default empty array.
  * @return string
  */
-function msls_get_switcher( $attr ): string {
+function msls_get_switcher( $attr = array() ): string {
 	$arr = is_array( $attr ) ? $attr : array();
 	$obj = apply_filters( 'msls_get_output', null );
 

--- a/tests/phpunit/TestApi.php
+++ b/tests/phpunit/TestApi.php
@@ -1,0 +1,45 @@
+<?php declare( strict_types=1 );
+
+namespace lloc\MslsTests;
+
+use Brain\Monkey\Functions;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+
+#[RunTestsInSeparateProcesses]
+#[PreserveGlobalState( false )]
+final class TestApi extends MslsUnitTestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		require_once __DIR__ . '/../../includes/api.php';
+	}
+
+	public function test_msls_get_switcher_without_arguments(): void {
+		Functions\expect( 'apply_filters' )->once()->with( 'msls_get_output', null )->andReturn( null );
+
+		$this->assertSame( '', msls_get_switcher() );
+	}
+
+	public function test_msls_get_switcher_with_array(): void {
+		$attr = array( 'before_item' => '<li>' );
+
+		$output = \Mockery::mock();
+		$output->shouldReceive( 'set_tags' )->once()->with( $attr )->andReturn( 'switcher' );
+
+		Functions\expect( 'apply_filters' )->once()->with( 'msls_get_output', null )->andReturn( $output );
+
+		$this->assertSame( 'switcher', msls_get_switcher( $attr ) );
+	}
+
+	public function test_msls_get_switcher_coerces_non_array_to_empty_array(): void {
+		$output = \Mockery::mock();
+		$output->shouldReceive( 'set_tags' )->once()->with( array() )->andReturn( 'switcher' );
+
+		Functions\expect( 'apply_filters' )->once()->with( 'msls_get_output', null )->andReturn( $output );
+
+		// The [sc_msls] shortcode passes '' when used without attributes.
+		$this->assertSame( 'switcher', msls_get_switcher( '' ) );
+	}
+}


### PR DESCRIPTION
## What

Gives the `$attr` parameter of `msls_get_switcher()` a default of `array()` so
the documented public template tag can be called with no arguments.

```php
// includes/api.php
-function msls_get_switcher( $attr ): string {
+function msls_get_switcher( $attr = array() ): string {
     $arr = is_array( $attr ) ? $attr : array();
     $obj = apply_filters( 'msls_get_output', null );
     return ! is_null( $obj ) ? strval( $obj->set_tags( $arr ) ) : '';
 }
```

Closes #643.

## Why

The body already coerces any non-array value to `array()`, so `$attr` was
effectively optional. But without a default, the natural template-tag call
`msls_get_switcher()` threw a fatal `ArgumentCountError` ("Too few arguments
… 0 passed and exactly 1 expected"). The sibling tag
`msls_the_switcher( array $arr = array() )` already defaults, so the two were
inconsistent. A downstream theme calling `msls_get_switcher()` with no args
currently has to pass `array()` purely to satisfy the signature.

## Backward compatibility

No behavior change for any existing caller:

- The parameter stays **untyped** so the `is_array()` coercion is preserved.
  This keeps the `[sc_msls]` shortcode
  (`add_shortcode( 'sc_msls', 'msls_get_switcher' )`) working — WordPress
  passes the empty string `''` when a shortcode has no attributes, which an
  `array` type hint would have rejected.
- Existing `msls_get_switcher( $attr )` calls are unaffected.
- The deprecated `get_the_msls( $attr )` shim is unaffected.

## Tests

Adds `tests/phpunit/TestApi.php` covering three cases:

- no-arg call → returns `''` when no output object is registered;
- explicit attribute array → forwarded to `set_tags()`;
- non-array value (`''`, the shortcode's no-attribute case) → coerced to
  `array()`.

The test runs in a separate process so loading `includes/api.php` does not
collide with the Brain Monkey function stubs used elsewhere in the suite.
Full suite green (431 tests). `composer phpcs` passes; `composer phpstan`
shows no new findings (the pre-existing errors are in unrelated files).

The `@since` tag uses `3.0.0`, the current unreleased version on `master`.

## Disclosure

Claude (Claude Code) assisted with this change. I reviewed the diff, ran the
test suite, phpcs and phpstan locally, and take responsibility for the change.